### PR TITLE
Add Continuous Integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
       - name: Install FastLED
-        run:
+        run: |
           - pio pkg install -g -l "https://github.com/FastLED/FastLED/archive/refs/heads/master.zip"
           - pio pkg install -g -l "links2004/WebSockets@^2.3.7"
       - name: Build Sketch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: PlatformIO CI
+
+  on: [push, pull_request]
+
+  jobs:
+    build:
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          example: [Code/FastLED_Test/FastLED_Test.ino]
+
+      steps:
+        - uses: actions/checkout@v3
+        - uses: actions/cache@v3
+          with:
+            path: |
+              ~/.cache/pip
+              ~/.platformio/.cache
+            key: ${{ runner.os }}-pio
+        - uses: actions/setup-python@v4
+          with:
+            python-version: '3.9'
+        - name: Install PlatformIO Core
+          run: pip install --upgrade platformio
+        - name: Install FastLED
+          run: pio pkg install -g -l "fastled/FastLED@^3.5.0"
+        - name: Build Sketches
+          run: pio ci --board=nodemcuv2
+          env:
+            PLATFORMIO_CI_SRC: ${{ matrix.example }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
       - name: Install FastLED
-        run: pio pkg install -g -l "fastled/FastLED@^3.5.0"
+        run:
+          - pio pkg install -g -l "https://github.com/FastLED/FastLED/archive/refs/heads/master.zip"
+          - pio pkg install -g -l "links2004/WebSockets@^2.3.7"
       - name: Build Sketch
         run: pio ci --board=nodemcuv2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        example: [Code/FastLED_Test/FastLED_Test.ino]
+        example: 
+          - Code/FastLED_Test
+          - Code/LED_Wall_Reciever
+          - Code/LED_Wall_Source
+          - Code/LMCSHD_Test
+          - Code/MAX_CURRENT_TEST
+          - Code/Single_LED_Wall_Reciever
+          - Code/Single_LED_Wall_Source
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -21,7 +28,7 @@ jobs:
         run: pip install --upgrade platformio
       - name: Install FastLED
         run: pio pkg install -g -l "fastled/FastLED@^3.5.0"
-      - name: Build Sketches
+      - name: Build Sketch
         run: pio ci --board=nodemcuv2
         env:
           PLATFORMIO_CI_SRC: ${{ matrix.example }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,30 +1,27 @@
 name: PlatformIO CI
-
-  on: [push, pull_request]
-
-  jobs:
-    build:
-      runs-on: ubuntu-latest
-      strategy:
-        matrix:
-          example: [Code/FastLED_Test/FastLED_Test.ino]
-
-      steps:
-        - uses: actions/checkout@v3
-        - uses: actions/cache@v3
-          with:
-            path: |
-              ~/.cache/pip
-              ~/.platformio/.cache
-            key: ${{ runner.os }}-pio
-        - uses: actions/setup-python@v4
-          with:
-            python-version: '3.9'
-        - name: Install PlatformIO Core
-          run: pip install --upgrade platformio
-        - name: Install FastLED
-          run: pio pkg install -g -l "fastled/FastLED@^3.5.0"
-        - name: Build Sketches
-          run: pio ci --board=nodemcuv2
-          env:
-            PLATFORMIO_CI_SRC: ${{ matrix.example }}
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example: [Code/FastLED_Test/FastLED_Test.ino]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+      - name: Install FastLED
+        run: pio pkg install -g -l "fastled/FastLED@^3.5.0"
+      - name: Build Sketches
+        run: pio ci --board=nodemcuv2
+        env:
+          PLATFORMIO_CI_SRC: ${{ matrix.example }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,11 @@ jobs:
           python-version: '3.9'
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
-      - name: Install FastLED
+      - name: Install Libraries
         run: |
           pio pkg install -g -l "https://github.com/FastLED/FastLED/archive/refs/heads/master.zip"
           pio pkg install -g -l "links2004/WebSockets@^2.3.7"
       - name: Build Sketch
-        run: pio ci --board=nodemcuv2
+        run: pio ci --board=d1_mini
         env:
           PLATFORMIO_CI_SRC: ${{ matrix.example }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
         run: pip install --upgrade platformio
       - name: Install FastLED
         run: |
-          - pio pkg install -g -l "https://github.com/FastLED/FastLED/archive/refs/heads/master.zip"
-          - pio pkg install -g -l "links2004/WebSockets@^2.3.7"
+          pio pkg install -g -l "https://github.com/FastLED/FastLED/archive/refs/heads/master.zip"
+          pio pkg install -g -l "links2004/WebSockets@^2.3.7"
       - name: Build Sketch
         run: pio ci --board=nodemcuv2
         env:


### PR DESCRIPTION
Enables Github Actions to test-compile each sketch contained in this repository for a Lolin D1 Mini using PlatformIO. Gives the commits their green ✔ when the build goes through. See [example run](https://github.com/maxgerhardt/Massive-LED-Wall/actions/runs/4147176060).

Squash upon merge is recommended.